### PR TITLE
fix: remove duplicate moyenne_g field

### DIFF
--- a/doudi/app/Models/Suggestion.php
+++ b/doudi/app/Models/Suggestion.php
@@ -7,8 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 
 class Suggestion extends Model
 {
-   
-    protected $fillable = ['id_user', 'niveau','specialite_bac', 'moyenne_g', 'moyenne_g' , 'moyenne_eco', 'moyenne_gestion', 'moyenne_math', 'moyenne_info' , 'moyenne_fr', 'etat' ,'proposition'];
-  
+    protected $fillable = ['id_user', 'niveau', 'specialite_bac', 'moyenne_g', 'moyenne_eco', 'moyenne_gestion', 'moyenne_math', 'moyenne_info', 'moyenne_fr', 'etat', 'proposition'];
    
 }


### PR DESCRIPTION
## Summary
- remove duplicated moyenne_g from Suggestion model fillable array

## Testing
- `composer install` *(fails: nette/schema requires php <8.3)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c3eabd85908322ab2799bb6a9f61c4