### PR TITLE
Use layout in etudiants index view

### DIFF
--- a/doudi/resources/views/etudiants/index.blade.php
+++ b/doudi/resources/views/etudiants/index.blade.php
@@ -1,7 +1,6 @@
 @extends('layouts.app')
-@section('content')
 
-  <body>
+@section('content')
     <div class="container">
 
         <div class="side-app">


### PR DESCRIPTION
## Summary
- Extend layouts.app in student index view
- Wrap page markup in a content section
- Drop stray `<body>` tag

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c3eac199608322901c2439f53c52ff