### PR TITLE
Refactor formations views

### DIFF
--- a/doudi/resources/views/formations/create.blade.php
+++ b/doudi/resources/views/formations/create.blade.php
@@ -2,47 +2,62 @@
 
 @section('content')
 <div class="page-leftheader">
-    <h4 class="page-title mb-0 text-primary">Ajouter une absence</h4>
+    <h4 class="page-title mb-0 text-primary">Ajouter une formation</h4>
 </div>
 <div class="card">
     <div class="card-header">
-        <a class="btn btn-primary buttons-copy buttons-html5" href = "{{route('absences')}}">Liste des absences</a>
+        <a class="btn btn-primary buttons-copy buttons-html5" href="{{ route('formations') }}">Liste des formations</a>
     </div>
     <div class="card-body pb-2">
-        <form class="" action="{{route('absence.store')}}" method="POST" enctype="multipart/form-data">
+        <form class="" action="{{ route('formation.store') }}" method="POST" enctype="multipart/form-data">
             @csrf
-        
+
             <div class="col-sm-6 col-md-6">
-            <div class="form-group">
-              <label class="form-label">Nom <span class="text-red">*</span></label>
-              <input type="text" class="form-control" placeholder="Entrer le nom de stagiaire absent "   name="nom">
+                <div class="form-group">
+                    <label class="form-label">Niveau <span class="text-red">*</span></label>
+                    <input type="text" class="form-control" placeholder="Entrer le niveau de la formation" name="niveau">
+                </div>
             </div>
-          </div>
-          <div class="col-sm-6 col-md-6">
-            <div class="form-group">
-              <label class="form-label">Prenom <span class="text-red">*</span></label>
-              <input type="text" class="form-control" placeholder="Entrer le prénom de stagiaire absent " name="prenom">
+
+            <div class="col-sm-6 col-md-6">
+                <div class="form-group">
+                    <label class="form-label">Spécialité <span class="text-red">*</span></label>
+                    <input type="text" class="form-control" placeholder="Entrer la spécialité de la formation" name="specialite">
+                </div>
             </div>
-          </div>
+
+            <div class="col-sm-6 col-md-6">
+                <div class="form-group">
+                    <label class="form-label">Groupe <span class="text-red">*</span></label>
+                    <input type="text" class="form-control" placeholder="Entrer le groupe de la formation" name="groupe">
+                </div>
+            </div>
+
             <div class="form-group">
-          <label for="exampleFormControlTextarea1">Justification</label>
-        
+                <label class="form-label">Formateurs <span class="text-red">*</span></label>
+                <input type="text" class="form-control" placeholder="Entrer les formateurs de la formation" name="formateurs">
+            </div>
 
-        <textarea class="form-control mb-4" placeholder="veuillez saisir la justification d'absence" rows="3" name="justification"></textarea>
-        </div>
-         
-          <div>
-            <label class="form-label">Veuillez saisir la date  d'absence<span class="text-red">*</span></label>
+            <div class="form-group">
+                <label class="form-label">Matières <span class="text-red">*</span></label>
+                <input type="text" class="form-control" placeholder="Entrer les matières de la formation" name="matieres">
+            </div>
 
-            <input type="date" id="bday" name="date">
-          </div></div>
-          <div class="form-group">
-           <button class="btn btn-pill btn-primary" type="submit">Enregister</button>
-           </div>
+            <div class="form-group">
+                <label class="form-label">Étudiants <span class="text-red">*</span></label>
+                <input type="text" class="form-control" placeholder="Entrer les étudiants de la formation" name="etudiants">
+            </div>
+
+            <div class="form-group">
+                <label for="description">Description</label>
+                <textarea class="form-control mb-4" placeholder="Veuillez saisir la description de la formation" rows="3" name="description"></textarea>
+            </div>
+
+            <div class="form-group">
+                <button class="btn btn-pill btn-primary" type="submit">Enregister</button>
+            </div>
         </form>
     </div>
 </div>
-
-
-
 @endsection
+

--- a/doudi/resources/views/formations/index.blade.php
+++ b/doudi/resources/views/formations/index.blade.php
@@ -10,7 +10,7 @@
             <!--Page header-->
             <div class="page-header">
                 <div class="page-leftheader">
-                    <h4 class="page-title mb-0 text-primary"><i class="ion-clipboard"></i>Liste des absences</h4>
+                    <h4 class="page-title mb-0 text-primary"><i class="ion-clipboard"></i>Liste des formations</h4>
                 </div>
                 <div class="page-rightheader">
                     <div class="btn-list">
@@ -53,21 +53,24 @@
                             <div class="">
                                 <div class="table-responsive">
                                 <div id="example_wrapper" class="dataTables_wrapper dt-bootstrap5 no-footer"><div class="row"><div class="col-sm-12 col-md-6"><div class="dataTables_length" id="example_length"><label><select name="example_length" aria-controls="example" class="form-select form-select-sm select2 select2-hidden-accessible" tabindex="-1" aria-hidden="true"><option value="10">10</option><option value="25">25</option><option value="50">50</option><option value="100">100</option></select>                                       
-                                        <a class="btn bg-success-transparent" href = "{{route('absences.create')}}"><i class="fe fe-edit"></i>Ajouter une absence </a>
+                                        <a class="btn bg-success-transparent" href = "{{route('formation.create')}}"><i class="fe fe-edit"></i>Ajouter une formation </a>
                                     </div>
                                     <div class="dt-buttons btn-group flex-wrap">
                                             </div> </div></div><div class="col-sm-12 col-md-6">
 
-                                                @if ($absences->count ()>0)
+                                                @if ($formations->count ()>0)
                                                 <div class="row"><div class="col-sm-12">
                                                     <table id="example" class="table table-bordered text-nowrap key-buttons dataTable no-footer" role="grid" aria-describedby="example_info">
 													<thead class="thead-dark">
 														<tr role="row">
                                                             <th scope="col">ID</th>
-                                                            <th scope="col">Nom de stagiaire absent</th>
-                                                            <th scope="col">Prenom de stagiaire absent</th>
-                                                            <th scope="col">Date</th>
-                                                            <th scope="col">Justification</th>
+                                                            <th scope="col">Niveau</th>
+                                                            <th scope="col">Spécialité</th>
+                                                            <th scope="col">Groupe</th>
+                                                            <th scope="col">Formateurs</th>
+                                                            <th scope="col">Matières</th>
+                                                            <th scope="col">Étudiants</th>
+                                                            <th scope="col">Description</th>
                                                             <th scope="col">Actions</th>
                                                         </tr>
 													</thead>
@@ -76,16 +79,19 @@
                                                     @php
                                                         $i= 1;
                                                     @endphp
-                                                    @foreach ($absences as $item )
+                                                    @foreach ($formations as $item )
 
                                                     <tr>
                                                         <th scope="row">{{$i++}}</th>
-                                                        <td>{{$item->nom}}</td>
-                                                        <td>{{$item->prenom}}</td>
-                                                        <td>{{$item->date}}</td>
-                                                        <td>{{$item->justification}}</td>
+                                                        <td>{{$item->niveau}}</td>
+                                                        <td>{{$item->specialite}}</td>
+                                                        <td>{{$item->groupe}}</td>
+                                                        <td>{{$item->formateurs}}</td>
+                                                        <td>{{$item->matieres}}</td>
+                                                        <td>{{$item->etudiants}}</td>
+                                                        <td>{{$item->description}}</td>
                                                         <td>  <a class="text-success" href = ""><button type="button" class="btn bg-warning-transparent"><i class="zmdi zmdi-collection-text"></i></button></a> &nbsp;&nbsp;
-                                                            <a class="text-warning" href = "{{route('absence.delete', ['id'=> $item->id])}}"><button type="button" class="btn bg-teal-transparent"><i class="fe fe-trash"></i></button> </a>&nbsp;&nbsp;</td>
+                                                            <a class="text-warning" href = "{{route('formation.delete', ['id'=> $item->id])}}"><button type="button" class="btn bg-teal-transparent"><i class="fe fe-trash"></i></button> </a>&nbsp;&nbsp;</td>
                                                       </tr>
                                                     @endforeach
                                                 </tbody>
@@ -93,7 +99,7 @@
                                                 @else
                                                 <div class="coll">
                                                 <div class="alert alert-danger" role="alert">
-                                                 pas des absences!
+                                                 pas de formations!
                                                 </div>
                                                 </div>
                                                 @endif


### PR DESCRIPTION
## Summary
- switch formations index to use `$formations` with formation-specific columns
- add formation creation form with fields for niveau, specialite, groupe and more

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c3eac26e74832287164aa7037c3f3e