### PR TITLE
Use named home route on welcome page

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -43,7 +43,7 @@
 
     <!-- Navbar Start -->
     <nav class="navbar navbar-expand-lg bg-white navbar-light shadow sticky-top p-0">
-        <a href="index.html" class="navbar-brand d-flex align-items-center px-4 px-lg-5">
+        <a href="{{ route('home') }}" class="navbar-brand d-flex align-items-center px-4 px-lg-5">
             <h2 class="m-0 text-primary"><i class="fa fa-book me-3"></i>Ecole de formation des cadres</h2>
         </a>
         <button type="button" class="navbar-toggler me-4" data-bs-toggle="collapse" data-bs-target="#navbarCollapse">
@@ -51,7 +51,7 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarCollapse">
             <div class="navbar-nav ms-auto p-4 p-lg-0">
-                <a href="index.html" class="nav-item nav-link active">Accueil</a>
+                <a href="{{ route('home') }}" class="nav-item nav-link active">Accueil</a>
                 <a href="about.html" class="nav-item nav-link">À propos</a>
                 <a href="courses.html" class="nav-item nav-link">Cours</a>
                 <div class="nav-item dropdown">


### PR DESCRIPTION
## Summary
- use `route('home')` for navbar logo and Accueil link in welcome view

## Testing
- `php artisan test` *(fails: vendor/autoload.php not found)*
- `composer install` *(fails: some packages require php < 8.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c481e190e88322a8a188da2d3379ff