### PR TITLE
Add Formations diplômantes section to homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -247,9 +247,36 @@
         </div>
     </div>
     <!-- Categories Start -->
-
-
-
+    <!-- Formations Start -->
+    <div class="container-xxl py-5">
+        <div class="container">
+            <div class="text-center wow fadeInUp" data-wow-delay="0.1s">
+                <h6 class="section-title bg-white text-center text-primary px-3">Formations diplômantes</h6>
+                <h1 class="mb-5">Nos diplômes</h1>
+            </div>
+            <div class="row g-4">
+                <div class="col-lg-6 wow fadeInUp" data-wow-delay="0.1s">
+                    <h5>BTS</h5>
+                    <ul>
+                        <li>Comptabilité et finances</li>
+                        <li>Commerce international (CFPF)</li>
+                        <li>Informatique de gestion</li>
+                        <li>Management de la qualité</li>
+                    </ul>
+                </div>
+                <div class="col-lg-6 wow fadeInUp" data-wow-delay="0.3s">
+                    <h5>BTP</h5>
+                    <ul>
+                        <li>Comptable d’entreprise</li>
+                        <li>Informaticien de gestion</li>
+                        <li>Secrétaire de direction (CFPF)</li>
+                        <li>Informatique industrielle (CFPF)</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- Formations End -->
 
     <!-- Team Start -->
     <div class="container-xxl py-5">


### PR DESCRIPTION
## Summary
- add "Formations diplômantes" section with BTS and BTP programs on index page

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c484176c548322bf3336cc7231130f