### PR TITLE
Add accelerated training section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -248,8 +248,34 @@
     </div>
     <!-- Categories Start -->
 
-
-
+    <!-- Formations accélérées Start -->
+    <div class="container-xxl py-5">
+        <div class="container">
+            <h2 class="mb-4 text-center">Formations accélérées</h2>
+            <div class="row">
+                <div class="col-md-6">
+                    <h4>Informatique</h4>
+                    <ul>
+                        <li>Bureautique</li>
+                        <li>Infographie</li>
+                        <li>Web design</li>
+                        <li>Montage vidéo</li>
+                        <li>Maintenance informatique</li>
+                    </ul>
+                </div>
+                <div class="col-md-6">
+                    <h4>Langues</h4>
+                    <ul>
+                        <li>Anglais</li>
+                        <li>Français</li>
+                        <li>Arabe</li>
+                    </ul>
+                </div>
+            </div>
+            <p class="mt-4 text-center">Anglais, Français et internet gratuits pour toute inscription.</p>
+        </div>
+    </div>
+    <!-- Formations accélérées End -->
 
     <!-- Team Start -->
     <div class="container-xxl py-5">


### PR DESCRIPTION
## Summary
- add "Formations accélérées" section to the homepage with IT and language modules

## Testing
- `npm test` *(fails: Missing script: "test")*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68c4841868f88322a7a2c46479695087