### PR TITLE
Add suggestion views

### DIFF
--- a/resources/views/suggestions/create.blade.php
+++ b/resources/views/suggestions/create.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Ajouter une suggestion</h1>
+    <form method="POST" action="{{ route('suggestion.store') }}">
+        @csrf
+        <div class="mb-3">
+            <label for="niveau" class="form-label">Niveau</label>
+            <input type="text" class="form-control" id="niveau" name="niveau" required>
+        </div>
+        <div class="mb-3">
+            <label for="specialite_bac" class="form-label">Spécialité du bac</label>
+            <input type="text" class="form-control" id="specialite_bac" name="specialite_bac" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_g" class="form-label">Moyenne générale</label>
+            <input type="text" class="form-control" id="moyenne_g" name="moyenne_g" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_math" class="form-label">Moyenne math</label>
+            <input type="text" class="form-control" id="moyenne_math" name="moyenne_math" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_eco" class="form-label">Moyenne économie</label>
+            <input type="text" class="form-control" id="moyenne_eco" name="moyenne_eco" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_gestion" class="form-label">Moyenne gestion</label>
+            <input type="text" class="form-control" id="moyenne_gestion" name="moyenne_gestion" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_info" class="form-label">Moyenne informatique</label>
+            <input type="text" class="form-control" id="moyenne_info" name="moyenne_info" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_fr" class="form-label">Moyenne français</label>
+            <input type="text" class="form-control" id="moyenne_fr" name="moyenne_fr" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Enregistrer</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/suggestions/edit.blade.php
+++ b/resources/views/suggestions/edit.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Modifier la suggestion</h1>
+    <form method="POST" action="{{ route('suggestion.update', $suggestion->id) }}">
+        @csrf
+        <div class="mb-3">
+            <label for="niveau" class="form-label">Niveau</label>
+            <input type="text" class="form-control" id="niveau" name="niveau" value="{{ $suggestion->niveau }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="specialite_bac" class="form-label">Spécialité du bac</label>
+            <input type="text" class="form-control" id="specialite_bac" name="specialite_bac" value="{{ $suggestion->specialite_bac }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_g" class="form-label">Moyenne générale</label>
+            <input type="text" class="form-control" id="moyenne_g" name="moyenne_g" value="{{ $suggestion->moyenne_g }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_math" class="form-label">Moyenne math</label>
+            <input type="text" class="form-control" id="moyenne_math" name="moyenne_math" value="{{ $suggestion->moyenne_math }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_eco" class="form-label">Moyenne économie</label>
+            <input type="text" class="form-control" id="moyenne_eco" name="moyenne_eco" value="{{ $suggestion->moyenne_eco }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_gestion" class="form-label">Moyenne gestion</label>
+            <input type="text" class="form-control" id="moyenne_gestion" name="moyenne_gestion" value="{{ $suggestion->moyenne_gestion }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_info" class="form-label">Moyenne informatique</label>
+            <input type="text" class="form-control" id="moyenne_info" name="moyenne_info" value="{{ $suggestion->moyenne_info }}" required>
+        </div>
+        <div class="mb-3">
+            <label for="moyenne_fr" class="form-label">Moyenne français</label>
+            <input type="text" class="form-control" id="moyenne_fr" name="moyenne_fr" value="{{ $suggestion->moyenne_fr }}" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Mettre à jour</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/suggestions/index.blade.php
+++ b/resources/views/suggestions/index.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Liste des suggestions</h1>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Niveau</th>
+                <th>Spécialité</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($suggestions as $suggestion)
+            <tr>
+                <td>{{ $suggestion->id }}</td>
+                <td>{{ $suggestion->niveau }}</td>
+                <td>{{ $suggestion->specialite_bac }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- add suggestion index view for listing
- add create and edit suggestion views with form fields

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c5310664a88322b794fc10b19cd819