### PR TITLE
Fix authentication section in welcome view

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -65,22 +65,23 @@
             </div>
 
               @if (Route::has('login'))
-        <ul class="navbar-nav ml-auto">
-            @auth
-              <li class="nav-item">
-               <a class="nav-link" href="{{ route('home') }}">Accueil</a>
-               </li>
-            @else
-               <li class="nav-item">
-               <a class="nav-link" href="{{ route('login') }}">Se connecter</a>
-              </li>
-               
-        </ul>
-        @endif
-         @if (Route::has('register'))
-            <a href="{{ route('register') }}" class="btn btn-primary py-4 px-lg-5 d-none d-lg-block">S'inscrire<i class="fa fa-arrow-right ms-3"></i></a>
-         @endif
-         @endauth
+                  @auth
+                      <ul class="navbar-nav ml-auto">
+                          <li class="nav-item">
+                              <a class="nav-link" href="{{ route('home') }}">Accueil</a>
+                          </li>
+                      </ul>
+                  @else
+                      <ul class="navbar-nav ml-auto">
+                          <li class="nav-item">
+                              <a class="nav-link" href="{{ route('login') }}">Se connecter</a>
+                          </li>
+                      </ul>
+                      @if (Route::has('register'))
+                          <a href="{{ route('register') }}" class="btn btn-primary py-4 px-lg-5 d-none d-lg-block">S'inscrire<i class="fa fa-arrow-right ms-3"></i></a>
+                      @endif
+                  @endauth
+              @endif
           </div>
     </nav>
     <!-- Navbar End -->


### PR DESCRIPTION
## Summary
- correct ordering of `@if`/`@auth` directives in the welcome view
- show login or registration links based on auth status

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/Dali/vendor/autoload.php')*
- `composer install` *(fails: nette/schema v1.2.3 requires php >=7.1 <8.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c53785e1b48322af6623de1a0ba914