### PR TITLE
Switch to role-based authorization

### DIFF
--- a/app/Http/Controllers/EtudiantController.php
+++ b/app/Http/Controllers/EtudiantController.php
@@ -7,13 +7,17 @@ use Illuminate\Http\Request;
 
 class EtudiantController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware(['auth', 'can:admin']);
+    }
     /**
      * Affiche la liste de tous les utilisateurs sauf l'admin (id=1).
      */
     public function index()
     {
         // Récupère tous les users sauf l'admin
-        $etudiants = User::where('id', '!=', 1)->get();
+        $etudiants = User::where('role', '!=', 'admin')->get();
 
         // Retourne la vue avec la liste
         return view('etudiants.index', compact('etudiants'));
@@ -24,12 +28,13 @@ class EtudiantController extends Controller
      */
     public function destroy($id)
     {
+        $user = User::findOrFail($id);
+
         // Vérifie qu'on ne supprime pas l'admin
-        if ($id == 1) {
+        if ($user->role === 'admin') {
             return redirect()->back()->with('error', "Impossible de supprimer l'administrateur !");
         }
 
-        $user = User::findOrFail($id);
         $user->delete();
 
         return redirect()->back()->with('success', 'Utilisateur supprimé avec succès.');

--- a/app/Http/Controllers/FormationController.php
+++ b/app/Http/Controllers/FormationController.php
@@ -18,6 +18,7 @@ class FormationController extends Controller
     public function __construct()
     {
         $this->middleware('auth');
+        $this->middleware('can:admin')->except(['index']);
     }
 
     /**

--- a/app/Http/Controllers/SuggestionController.php
+++ b/app/Http/Controllers/SuggestionController.php
@@ -18,6 +18,7 @@ class SuggestionController extends Controller
     public function __construct()
     {
         $this->middleware('auth');
+        $this->middleware('can:admin')->except(['create', 'store']);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,7 +2,8 @@
 
 namespace App\Providers;
 
-// use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Gate;
+use App\Models\User;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -25,6 +26,8 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        //
+        Gate::define('admin', function (User $user) {
+            return $user->role === 'admin';
+        });
     }
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -65,8 +65,8 @@
 
     <ul class="side-menu app-sidebar3">
 
-        @if(Auth::check() && Auth::user()->id == 1)
-            {{-- Sidebar pour l’admin (id = 1) --}}
+        @can('admin')
+            {{-- Sidebar pour l’admin --}}
             <li class="slide">
                 <a class="side-menu__item" href="">
                     <svg xmlns="http://www.w3.org/2000/svg" class="side-menu__icon" width="24" height="24" fill="currentColor" viewBox="0 0 16 16">
@@ -126,7 +126,7 @@
                     <span class="side-menu__label">Mes Suggestions</span>
                 </a>
             </li>
-        @endif
+        @endcan
 
     </ul>
 </aside>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,23 +24,28 @@ Route::get('/', function () {
 Auth::routes();
 
 
-Route::get('/etudiants', [EtudiantController::class, 'index'])->name('etudiants.index');
-Route::delete('/etudiants/{id}', [EtudiantController::class, 'destroy'])->name('etudiants.destroy');
+Route::middleware('can:admin')->group(function () {
+    Route::get('/etudiants', [EtudiantController::class, 'index'])->name('etudiants.index');
+    Route::delete('/etudiants/{id}', [EtudiantController::class, 'destroy'])->name('etudiants.destroy');
 
+    // formations (admin)
+    Route::get('/formation/delete/{id}', [FormationController::class, 'destroy'])->name('formation.delete');
+    Route::get('/formation/create', [FormationController::class, 'create'])->name('formation.create');
+    Route::post('/formation/store', [FormationController::class, 'store'])->name('formation.store');
+    Route::get('/formation/edit/{id}', [FormationController::class, 'edit'])->name('formation.edit');
+    Route::post('/formation/update/{id}', [FormationController::class, 'update'])->name('formation.update');
 
-//formations
+    // suggestions (admin)
+    Route::get('/suggestions', [SuggestionController::class, 'index'])->name('suggestions');
+    Route::get('/suggestion/delete/{id}', [SuggestionController::class, 'destroy'])->name('suggestion.delete');
+    Route::get('/suggestion/edit/{id}', [SuggestionController::class, 'edit'])->name('suggestion.edit');
+    Route::post('/suggestion/update/{id}', [SuggestionController::class, 'update'])->name('suggestion.update');
+});
+
+// formations accessible à tous les utilisateurs authentifiés
 Route::get('/formations', [FormationController::class, 'index'])->name('formations');
-Route::get('/formation/delete/{id}', [FormationController::class, 'destroy'])->name('formation.delete');
-Route::get('/formation/create', [FormationController::class, 'create'])->name('formation.create');
-Route::post('/formation/store', [FormationController::class, 'store'])->name('formation.store');
-Route::get('/formation/edit/{id}', [FormationController::class, 'edit'])->name('formation.edit');
-Route::post('/formation/update/{id}', [FormationController::class, 'update'])->name('formation.update');
 
-//suggestions
-Route::get('/suggestions', [SuggestionController::class, 'index'])->name('suggestions');
-Route::get('/suggestion/delete/{id}', [SuggestionController::class, 'destroy'])->name('suggestion.delete');
+// suggestions (création par les utilisateurs)
 Route::get('/suggestion/create', [SuggestionController::class, 'create'])->name('suggestion.create');
 Route::post('/suggestion/store', [SuggestionController::class, 'store'])->name('suggestion.store');
-Route::get('/suggestion/edit/{id}', [SuggestionController::class, 'edit'])->name('suggestion.edit');
-Route::post('/suggestion/update/{id}', [SuggestionController::class, 'update'])->name('suggestion.update');
 


### PR DESCRIPTION
## Summary
- show menu items based on admin role via `@can`
- add authorization gate and controller middleware using `role` field
- restrict routes to admin and expose non-admin creation routes

## Testing
- `php -l app/Http/Controllers/EtudiantController.php app/Http/Controllers/FormationController.php app/Http/Controllers/SuggestionController.php app/Models/User.php app/Providers/AuthServiceProvider.php routes/web.php`
- `php artisan test` *(fails: require(/workspace/Dali/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68c53787aa808322a8cf0336d4a07d8c