### PR TITLE
Translate instructor section to French

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -181,8 +181,8 @@
     <div class="container-xxl py-5">
         <div class="container">
             <div class="text-center wow fadeInUp" data-wow-delay="0.1s">
-                <h6 class="section-title bg-white text-center text-primary px-3">Instructors</h6>
-                <h1 class="mb-5">Expert Instructors</h1>
+                <h6 class="section-title bg-white text-center text-primary px-3">Instructeurs</h6>
+                <h1 class="mb-5">Instructeurs experts</h1>
             </div>
             <div class="row g-4">
                 <div class="col-lg-3 col-md-6 wow fadeInUp" data-wow-delay="0.1s">

--- a/public/index.html
+++ b/public/index.html
@@ -314,8 +314,8 @@
     <div class="container-xxl py-5">
         <div class="container">
             <div class="text-center wow fadeInUp" data-wow-delay="0.1s">
-                <h6 class="section-title bg-white text-center text-primary px-3">Instructors</h6>
-                <h1 class="mb-5">Expert Instructors</h1>
+                <h6 class="section-title bg-white text-center text-primary px-3">Instructeurs</h6>
+                <h1 class="mb-5">Instructeurs experts</h1>
             </div>
             <div class="row g-4">
                 <div class="col-lg-3 col-md-6 wow fadeInUp" data-wow-delay="0.1s">

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -117,8 +117,8 @@
     <div class="container-xxl py-5">
         <div class="container">
             <div class="text-center wow fadeInUp" data-wow-delay="0.1s">
-                <h6 class="section-title bg-white text-center text-primary px-3">Instructors</h6>
-                <h1 class="mb-5">Expert Instructors</h1>
+                <h6 class="section-title bg-white text-center text-primary px-3">Instructeurs</h6>
+                <h1 class="mb-5">Instructeurs experts</h1>
             </div>
             <div class="row g-4">
                 <div class="col-lg-3 col-md-6 wow fadeInUp" data-wow-delay="0.1s">


### PR DESCRIPTION
## Summary
- Replace "Expert Instructors" headings with "Instructeurs experts" across views and static pages.
- Localize section labels from "Instructors" to "Instructeurs".

## Testing
- `composer install --no-interaction --no-progress` *(fails: your lock file does not contain a compatible set of packages due to PHP 8.4)*
- `composer install --no-interaction --no-progress --ignore-platform-reqs` *(fails: unable to download packages from GitHub, CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c542a96bec8322b915141b8cab54a4