### PR TITLE
Remove breadcrumb navigation from pages

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -73,13 +73,6 @@
             <div class="row justify-content-center">
                 <div class="col-lg-10 text-center">
                     <h1 class="display-3 text-white animated slideInDown">À propos de nous</h1>
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb justify-content-center">
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Accueil</a></li>
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Pages</a></li>
-                            <li class="breadcrumb-item text-white active" aria-current="page">À propos</li>
-                        </ol>
-                    </nav>
                 </div>
             </div>
         </div>

--- a/public/team.html
+++ b/public/team.html
@@ -73,13 +73,6 @@
             <div class="row justify-content-center">
                 <div class="col-lg-10 text-center">
                     <h1 class="display-3 text-white animated slideInDown">Notre équipe</h1>
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb justify-content-center">
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Accueil</a></li>
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Pages</a></li>
-                            <li class="breadcrumb-item text-white active" aria-current="page">Notre équipe</li>
-                        </ol>
-                    </nav>
                 </div>
             </div>
         </div>

--- a/public/testimonial.html
+++ b/public/testimonial.html
@@ -73,13 +73,6 @@
             <div class="row justify-content-center">
                 <div class="col-lg-10 text-center">
                     <h1 class="display-3 text-white animated slideInDown">Témoignages</h1>
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb justify-content-center">
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Accueil</a></li>
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Pages</a></li>
-                            <li class="breadcrumb-item text-white active" aria-current="page">Témoignages</li>
-                        </ol>
-                    </nav>
                 </div>
             </div>
         </div>

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -9,13 +9,6 @@
             <div class="row justify-content-center">
                 <div class="col-lg-10 text-center">
                     <h1 class="display-3 text-white animated slideInDown">À propos de nous</h1>
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb justify-content-center">
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Accueil</a></li>
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Pages</a></li>
-                            <li class="breadcrumb-item text-white active" aria-current="page">À propos</li>
-                        </ol>
-                    </nav>
                 </div>
             </div>
         </div>

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -7,12 +7,6 @@
             <div class="row justify-content-center">
                 <div class="col-lg-10 text-center">
                     <h1 class="display-3 text-white animated slideInDown">Contactez-nous</h1>
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb justify-content-center">
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Accueil</a></li>
-                            <li class="breadcrumb-item text-white active" aria-current="page">Contact</li>
-                        </ol>
-                    </nav>
                 </div>
             </div>
         </div>

--- a/resources/views/team.blade.php
+++ b/resources/views/team.blade.php
@@ -9,13 +9,6 @@
             <div class="row justify-content-center">
                 <div class="col-lg-10 text-center">
                     <h1 class="display-3 text-white animated slideInDown">Notre équipe</h1>
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb justify-content-center">
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Accueil</a></li>
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Pages</a></li>
-                            <li class="breadcrumb-item text-white active" aria-current="page">Notre équipe</li>
-                        </ol>
-                    </nav>
                 </div>
             </div>
         </div>

--- a/resources/views/testimonial.blade.php
+++ b/resources/views/testimonial.blade.php
@@ -9,13 +9,6 @@
             <div class="row justify-content-center">
                 <div class="col-lg-10 text-center">
                     <h1 class="display-3 text-white animated slideInDown">Témoignages</h1>
-                    <nav aria-label="breadcrumb">
-                        <ol class="breadcrumb justify-content-center">
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Accueil</a></li>
-                            <li class="breadcrumb-item"><a class="text-white" href="#">Pages</a></li>
-                            <li class="breadcrumb-item text-white active" aria-current="page">Témoignages</li>
-                        </ol>
-                    </nav>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Remove breadcrumb navigation markup from team, about, testimonial, and contact Blade views.
- Mirror the breadcrumb removal in static public HTML templates.

## Testing
- ⚠️ `composer install` *(failed: nette/schema requires PHP < 8.3)*
- ⚠️ `composer install --ignore-platform-reqs` *(failed: GitHub token required)*
- ⚠️ `vendor/bin/phpunit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5484b68488322be7fe5fb67e63ef2