### PR TITLE
Introduce course and instructor structure with seeders

### DIFF
--- a/app/Http/Controllers/StudentDashboardController.php
+++ b/app/Http/Controllers/StudentDashboardController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Formation;
+
+class StudentDashboardController extends Controller
+{
+    public function index()
+    {
+        $formations = Formation::with('courses.resources', 'courses.schedules', 'instructors')->get();
+        return view('espace-etudiant', compact('formations'));
+    }
+}
+

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Course extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'formation_id',
+        'title',
+        'description',
+    ];
+
+    public function formation()
+    {
+        return $this->belongsTo(Formation::class);
+    }
+
+    public function resources()
+    {
+        return $this->hasMany(Resource::class);
+    }
+
+    public function schedules()
+    {
+        return $this->hasMany(Schedule::class);
+    }
+
+    public function instructors()
+    {
+        return $this->belongsToMany(Instructor::class);
+    }
+}
+

--- a/app/Models/Formation.php
+++ b/app/Models/Formation.php
@@ -7,8 +7,18 @@ use Illuminate\Database\Eloquent\Model;
 
 class Formation extends Model
 {
-   
-    protected $fillable = ['niveau', 'specialite','formateurs', 'matieres' , 'description' ,'etudiants', 'groupe'];
+    use HasFactory;
 
-   
+    protected $fillable = ['niveau', 'specialite', 'description'];
+
+    public function courses()
+    {
+        return $this->hasMany(Course::class);
+    }
+
+    public function instructors()
+    {
+        return $this->belongsToMany(Instructor::class);
+    }
 }
+

--- a/app/Models/Instructor.php
+++ b/app/Models/Instructor.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Instructor extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'contact',
+    ];
+
+    public function courses()
+    {
+        return $this->belongsToMany(Course::class);
+    }
+
+    public function formations()
+    {
+        return $this->belongsToMany(Formation::class);
+    }
+}
+

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Resource extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'course_id',
+        'type',
+        'url',
+    ];
+
+    public function course()
+    {
+        return $this->belongsTo(Course::class);
+    }
+}
+

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Schedule extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'course_id',
+        'day',
+        'time',
+    ];
+
+    public function course()
+    {
+        return $this->belongsTo(Course::class);
+    }
+}
+

--- a/database/migrations/2024_05_18_000000_create_courses_table.php
+++ b/database/migrations/2024_05_18_000000_create_courses_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('courses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('formation_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('courses');
+    }
+};
+

--- a/database/migrations/2024_05_18_000001_create_resources_table.php
+++ b/database/migrations/2024_05_18_000001_create_resources_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('resources', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->string('url');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('resources');
+    }
+};
+

--- a/database/migrations/2024_05_18_000002_create_schedules_table.php
+++ b/database/migrations/2024_05_18_000002_create_schedules_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('schedules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained()->cascadeOnDelete();
+            $table->string('day');
+            $table->string('time');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('schedules');
+    }
+};
+

--- a/database/migrations/2024_05_18_000003_create_instructors_table.php
+++ b/database/migrations/2024_05_18_000003_create_instructors_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('instructors', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('contact')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('instructors');
+    }
+};
+

--- a/database/migrations/2024_05_18_000004_create_course_instructor_table.php
+++ b/database/migrations/2024_05_18_000004_create_course_instructor_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('course_instructor', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('instructor_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('course_instructor');
+    }
+};
+

--- a/database/migrations/2024_05_18_000005_create_formation_instructor_table.php
+++ b/database/migrations/2024_05_18_000005_create_formation_instructor_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('formation_instructor', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('formation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('instructor_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('formation_instructor');
+    }
+};
+

--- a/database/seeders/CourseSeeder.php
+++ b/database/seeders/CourseSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Formation;
+use App\Models\Course;
+use App\Models\Resource;
+use App\Models\Schedule;
+use App\Models\Instructor;
+
+class CourseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $formation = Formation::firstOrCreate([
+            'niveau' => 'Licence',
+            'specialite' => 'Informatique',
+            'description' => 'Programme informatique',
+        ]);
+
+        $course = $formation->courses()->create([
+            'title' => 'Programmation PHP',
+            'description' => 'Introduction à Laravel',
+        ]);
+
+        $instructor = Instructor::firstOrCreate([
+            'name' => 'John Doe',
+            'contact' => 'john@example.com',
+        ]);
+
+        $course->instructors()->attach($instructor);
+
+        $course->resources()->create([
+            'type' => 'pdf',
+            'url' => 'http://example.com/intro.pdf',
+        ]);
+
+        $course->schedules()->create([
+            'day' => 'Lundi',
+            'time' => '09:00',
+        ]);
+
+        // link instructor to formation
+        $formation->instructors()->attach($instructor);
+    }
+}
+

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,11 +14,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        $this->call([
+            InstructorSeeder::class,
+            CourseSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/InstructorSeeder.php
+++ b/database/seeders/InstructorSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Instructor;
+
+class InstructorSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Instructor::create([
+            'name' => 'John Doe',
+            'contact' => 'john@example.com',
+        ]);
+    }
+}
+

--- a/resources/views/espace-etudiant.blade.php
+++ b/resources/views/espace-etudiant.blade.php
@@ -14,5 +14,37 @@
     </div>
     <!-- Header End -->
 
+    <div class="container my-5">
+        @foreach($formations as $formation)
+            <div class="mb-4">
+                <h2>{{ $formation->specialite }} ({{ $formation->niveau }})</h2>
+                <h5>Formateurs :</h5>
+                <ul>
+                    @foreach($formation->instructors as $instructor)
+                        <li>{{ $instructor->name }}</li>
+                    @endforeach
+                </ul>
+                @foreach($formation->courses as $course)
+                    <div class="ms-3">
+                        <h4>{{ $course->title }}</h4>
+                        <p>{{ $course->description }}</p>
+                        <h6>Ressources :</h6>
+                        <ul>
+                            @foreach($course->resources as $resource)
+                                <li><a href="{{ $resource->url }}">{{ $resource->type }}</a></li>
+                            @endforeach
+                        </ul>
+                        <h6>Emploi du temps :</h6>
+                        <ul>
+                            @foreach($course->schedules as $schedule)
+                                <li>{{ $schedule->day }} - {{ $schedule->time }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endforeach
+            </div>
+        @endforeach
+    </div>
+
 @endsection
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\EtudiantController;
 use App\Http\Controllers\FormationController;
 use App\Http\Controllers\SuggestionController;
+use App\Http\Controllers\StudentDashboardController;
 
 /*
 |--------------------------------------------------------------------------
@@ -54,5 +55,5 @@ Route::view('/about', 'about')->name('about');
 Route::view('/team', 'team')->name('team');
 Route::view('/testimonial', 'testimonial')->name('testimonial');
 Route::view('/contact', 'contact')->name('contact');
-Route::view('/espace-etudiant', 'espace-etudiant')->name('espace-etudiant');
+Route::get('/espace-etudiant', [StudentDashboardController::class, 'index'])->name('espace-etudiant');
 Route::view('/espace-admin', 'espace-admin')->name('espace-admin');


### PR DESCRIPTION
## Summary
- Add Course, Resource, Schedule, and Instructor models with migrations and relationships
- Update Formation and student dashboard to use new relations
- Seed example formation, courses, instructors, resources and schedules

## Testing
- `php -l app/Models/Course.php app/Models/Resource.php app/Models/Schedule.php app/Models/Instructor.php app/Models/Formation.php app/Http/Controllers/StudentDashboardController.php`
- `php -l database/migrations/2024_05_18_000000_create_courses_table.php database/migrations/2024_05_18_000001_create_resources_table.php database/migrations/2024_05_18_000002_create_schedules_table.php database/migrations/2024_05_18_000003_create_instructors_table.php database/migrations/2024_05_18_000004_create_course_instructor_table.php database/migrations/2024_05_18_000005_create_formation_instructor_table.php`
- `php artisan test` *(fails: require(/workspace/Dali/vendor/autoload.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c555af687883229dbaad8148a081b7