### PR TITLE
Fix student dashboard routing

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -57,6 +57,6 @@ Route::view('/about', 'about')->name('about');
 Route::view('/team', 'team')->name('team');
 Route::view('/testimonial', 'testimonial')->name('testimonial');
 Route::view('/contact', 'contact')->name('contact');
-Route::view('/espace-etudiant', 'espace-etudiant')->name('espace-etudiant');
+Route::get('/espace-etudiant', [StudentDashboardController::class, 'index'])->name('espace-etudiant');
 Route::view('/espace-admin-demo', 'espace-admin-demo')->name('espace-admin-demo');
 


### PR DESCRIPTION
## Summary
- Use `StudentDashboardController` to render `/espace-etudiant` so formations data is provided

## Testing
- `php -l routes/web.php`
- `php artisan test` *(fails: require vendor/autoload.php; `composer install` requires GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c55b14cd2083229b79ab95619b9a73