### PR TITLE
Ouvrir l'espace enseignant pour la démo

### DIFF
--- a/resources/views/espace-enseignant.blade.php
+++ b/resources/views/espace-enseignant.blade.php
@@ -1,0 +1,21 @@
+@extends('layouts.front')
+
+@section('content')
+    <!-- Header Start -->
+    <div class="container-fluid bg-primary py-5 mb-5 page-header">
+        <div class="container py-5">
+            <div class="row justify-content-center">
+                <div class="col-lg-10 text-center">
+                    <h1 class="display-3 text-white animated slideInDown">Espace Enseignant (Demo)</h1>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- Header End -->
+
+    <div class="container my-5">
+        <div class="alert alert-warning">
+            Cet espace enseignant est accessible librement dans le cadre d'une démo ouverte.
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,5 +58,9 @@ Route::view('/team', 'team')->name('team');
 Route::view('/testimonial', 'testimonial')->name('testimonial');
 Route::view('/contact', 'contact')->name('contact');
 Route::get('/espace-etudiant', [StudentDashboardController::class, 'index'])->name('espace-etudiant');
+Route::middleware([])->group(function () {
+    // Ancien middleware ['auth', 'can:enseignant'] retiré pour la démo
+    Route::view('/espace-enseignant', 'espace-enseignant')->name('espace-enseignant');
+});
 Route::view('/espace-admin-demo', 'espace-admin-demo')->name('espace-admin-demo');
 


### PR DESCRIPTION
## Summary
- Retire le middleware enseignant pour rendre l'espace enseignant accessible sans authentification
- Ajoute la vue `espace-enseignant` avec un avertissement indiquant qu'il s'agit d'une démo ouverte

## Testing
- `php -l routes/web.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: nette/schema requires php <8.3 while PHP is 8.4.12)*

------
https://chatgpt.com/codex/tasks/task_e_68c55e64214483229ac11816a17fa8b0