### PR TITLE
Add users table migration

### DIFF
--- a/database/migrations/2024_05_19_000006_create_users_table.php
+++ b/database/migrations/2024_05_19_000006_create_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('role');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};


### PR DESCRIPTION
## Summary
- add migration for users table with fields for name, unique email, password, role and auth helpers

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=/workspace/Dali/database/database.sqlite php artisan migrate` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ed4af3b48322a8c5a8ee3b6187da