### PR TITLE
Add username field to user registration

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -50,8 +50,9 @@ class RegisterController extends Controller
     protected function validator(array $data)
     {
         return Validator::make($data, [
+            'username' => ['required', 'string', 'max:50', 'unique:users,username'],
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ]);
     }
@@ -65,6 +66,7 @@ class RegisterController extends Controller
     protected function create(array $data)
     {
         return User::create([
+            'username' => $data['username'],
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -18,6 +18,7 @@ class User extends Authenticatable
      * @var array<int, string>
      */
     protected $fillable = [
+        'username',
         'name',
         'email',
         'password',

--- a/database/migrations/2024_05_19_000006_create_users_table.php
+++ b/database/migrations/2024_05_19_000006_create_users_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
+            $table->string('username', 50)->unique();
             $table->string('name');
             $table->string('email')->unique();
             $table->string('password');

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -62,14 +62,26 @@
         <form method="POST" action="{{ route('register') }}">
             @csrf
 
+            <!-- Username -->
+            <label class="label">Nom d'utilisateur</label>
+            <input class="input @error('username') is-invalid @enderror"
+                   type="text"
+                   name="username"
+                   value="{{ old('username') }}"
+                   placeholder="Choisissez un pseudo"
+                   required autofocus>
+            @error('username')
+                <span class="invalid-feedback"><strong>{{ $message }}</strong></span>
+            @enderror
+
             <!-- Nom -->
             <label class="label">Nom complet</label>
             <input class="input @error('name') is-invalid @enderror"
-                   type="text" 
-                   name="name" 
-                   value="{{ old('name') }}" 
-                   placeholder="Votre nom" 
-                   required autofocus>
+                   type="text"
+                   name="name"
+                   value="{{ old('name') }}"
+                   placeholder="Votre nom"
+                   required>
             @error('name')
                 <span class="invalid-feedback"><strong>{{ $message }}</strong></span>
             @enderror


### PR DESCRIPTION
## Summary
- Require unique `username` during user sign-up and store it in the database
- Allow mass assignment for `username` in the user model
- Include `username` field in registration form and migration

## Testing
- `php artisan test` *(fails: Failed to open required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c6f520c5dc83229d2500f60bed1530